### PR TITLE
Changing asyncio to use proxy

### DIFF
--- a/academy/exchange/cloud/client.py
+++ b/academy/exchange/cloud/client.py
@@ -113,6 +113,7 @@ class HttpExchangeTransport(ExchangeTransportMixin, NoPickleMixin):
         session = aiohttp.ClientSession(
             connector=aiohttp.TCPConnector(ssl=ssl_verify),
             headers=connection_info.additional_headers,
+            trust_env=True,
         )
 
         if mailbox_id is None:


### PR DESCRIPTION
## Summary
Asyncio does not use the proxy environment variables by default. On Aurora and other HPC systems, the proxies are necessary to get outbound internet access from compute nodes to connect to the exchange.

## Changes
<!--- Check which of the following changes were made --->

- [ ] Breaking (backwards incompatible changes to public interfaces)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change or feature addition)
- [ ] Refactor (internal code or design clean up)
- [ ] Documentation (no changes to the code)
- [ ] Test (changes or additions to testing)
- [ ] Build (change to CI workflows or build processes)
- [ ] Package (changes to package metadata or dependency versions)

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added based on the types of changes.
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [ ] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
