### PR TITLE
Option to Reject Actions when Agent is Inactive

### DIFF
--- a/academy/exception.py
+++ b/academy/exception.py
@@ -72,6 +72,17 @@ class PingCancelledError(Exception):
         return type(self), ()
 
 
+class AgentInactiveError(Exception):
+    """Agent is inactive."""
+
+    def __init__(self, uid: AgentId[Any]) -> None:
+        super().__init__(
+            f'Agent {uid} is inactive; handle is configured to reject '
+            'actions when agent is inactive.',
+        )
+        self.uid = uid
+
+
 class ExchangeError(Exception):
     """Base type for exchange related errors."""
 

--- a/academy/exchange/__init__.py
+++ b/academy/exchange/__init__.py
@@ -12,12 +12,12 @@ from academy.exchange.hybrid import HybridExchangeFactory
 from academy.exchange.hybrid import HybridExchangeTransport
 from academy.exchange.local import LocalExchangeFactory
 from academy.exchange.local import LocalExchangeTransport
+from academy.exchange.mailbox_status import MailboxStatus
 from academy.exchange.proxystore import ProxyStoreExchangeFactory
 from academy.exchange.proxystore import ProxyStoreExchangeTransport
 from academy.exchange.redis import RedisExchangeFactory
 from academy.exchange.redis import RedisExchangeTransport
 from academy.exchange.transport import ExchangeTransport
-from academy.exchange.transport import MailboxStatus
 
 __all__ = [
     'AgentExchangeClient',

--- a/academy/exchange/client.py
+++ b/academy/exchange/client.py
@@ -8,6 +8,7 @@ import sys
 import uuid
 from collections.abc import Callable
 from collections.abc import Coroutine
+from contextvars import ContextVar
 from types import TracebackType
 from typing import Any
 from typing import Generic
@@ -25,11 +26,9 @@ else:  # pragma: <3.11 cover
 from academy.exception import BadEntityIdError
 from academy.exception import MailboxTerminatedError
 from academy.exchange.client_config import ExchangeClientConfig
+from academy.exchange.mailbox_status import MailboxStatus
 from academy.exchange.transport import AgentRegistration
 from academy.exchange.transport import ExchangeTransportT
-from academy.exchange.transport import MailboxStatus
-from academy.handle import exchange_context
-from academy.handle import Handle
 from academy.identifier import AgentId
 from academy.identifier import EntityId
 from academy.identifier import UserId
@@ -45,6 +44,7 @@ if TYPE_CHECKING:
     from academy.agent import Agent
     from academy.agent import AgentT
     from academy.exchange.factory import ExchangeFactory
+    from academy.handle import Handle
 else:
     AgentT = TypeVar('AgentT')
 
@@ -55,6 +55,9 @@ RequestHandler: TypeAlias = Callable[
     [Message[RequestT_co]],
     Coroutine[None, None, None],
 ]
+exchange_context: ContextVar[ExchangeClient[Any]] = ContextVar(
+    'exchange_context',
+)
 
 
 class ExchangeClient(abc.ABC, Generic[ExchangeTransportT]):

--- a/academy/exchange/cloud/app.py
+++ b/academy/exchange/cloud/app.py
@@ -63,7 +63,7 @@ from academy.exchange.cloud.authenticate import get_authenticator
 from academy.exchange.cloud.backend import MailboxBackend
 from academy.exchange.cloud.client_info import ClientInfo
 from academy.exchange.cloud.config import ExchangeServingConfig
-from academy.exchange.transport import MailboxStatus
+from academy.exchange.mailbox_status import MailboxStatus
 from academy.identifier import EntityId
 from academy.message import Message
 

--- a/academy/exchange/cloud/backend.py
+++ b/academy/exchange/cloud/backend.py
@@ -29,8 +29,8 @@ from academy.exception import BadEntityIdError
 from academy.exception import ForbiddenError
 from academy.exception import MailboxTerminatedError
 from academy.exception import MessageTooLargeError
+from academy.exchange.mailbox_status import MailboxStatus
 from academy.exchange.transport import _respond_pending_requests_on_terminate
-from academy.exchange.transport import MailboxStatus
 from academy.identifier import AgentId
 from academy.identifier import EntityId
 from academy.message import Header

--- a/academy/exchange/mailbox_status.py
+++ b/academy/exchange/mailbox_status.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import enum
+
+
+class MailboxStatus(enum.Enum):
+    """Exchange mailbox status."""
+
+    MISSING = 'MISSING'
+    """Mailbox does not exist."""
+    ACTIVE = 'ACTIVE'
+    """Mailbox exists and is accepting messages."""
+    INACTIVE = 'INACTIVE'
+    """Mailbox accepting messages but has missed heartbeats."""
+    TERMINATED = 'TERMINATED'
+    """Mailbox was terminated and no longer accepts messages."""

--- a/academy/exchange/transport.py
+++ b/academy/exchange/transport.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import contextlib
-import enum
 import sys
 from collections.abc import AsyncGenerator
 from collections.abc import Awaitable
@@ -33,19 +32,6 @@ if TYPE_CHECKING:
     from academy.exchange.factory import ExchangeFactory
 else:
     from academy.identifier import AgentT
-
-
-class MailboxStatus(enum.Enum):
-    """Exchange mailbox status."""
-
-    MISSING = 'MISSING'
-    """Mailbox does not exist."""
-    ACTIVE = 'ACTIVE'
-    """Mailbox exists and is accepting messages."""
-    INACTIVE = 'INACTIVE'
-    """Mailbox accepting messages but has missed heartbeats."""
-    TERMINATED = 'TERMINATED'
-    """Mailbox was terminated and no longer accepts messages."""
 
 
 @runtime_checkable

--- a/academy/handle.py
+++ b/academy/handle.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import functools
 import logging
 import time
@@ -14,8 +15,10 @@ from typing import TYPE_CHECKING
 from typing import TypeVar
 from weakref import WeakSet
 
+from academy.exception import AgentInactiveError
 from academy.exception import AgentTerminatedError
 from academy.exception import ExchangeClientNotFoundError
+from academy.exchange.transport import MailboxStatus
 from academy.identifier import AgentId
 from academy.message import ActionRequest
 from academy.message import ActionResponse
@@ -79,6 +82,8 @@ class Handle(Generic[AgentT_co]):
     Args:
         agent_id: ID of the remote agent, or ``None`` to defer
             binding (used by ``batch.queue()``).
+        reject_on_inactive: Return an error when target agent is inactive.
+            Needs to be a positional argument for serialization.
         exchange: A default exchange client to be used if an exchange client
             is not configured in the current context.
         ignore_context: Ignore the current context and force use of `exchange`
@@ -90,6 +95,7 @@ class Handle(Generic[AgentT_co]):
             the same strategy as the request serializer.
         exception_serializer: Strategy used to serialize results. If false-y,
             use the same strategy as the result serializer.
+        polling_interval: Interval to poll exchange to see if agent is active.
 
     Raises:
         ValueError: If `ignore_context=True` but `exchange` is not provided.
@@ -98,12 +104,14 @@ class Handle(Generic[AgentT_co]):
     def __init__(  # noqa: PLR0913
         self,
         agent_id: AgentId[AgentT_co] | None = None,
+        reject_on_inactive: bool = False,
         *,
         exchange: ExchangeClient[Any] | None = None,
         ignore_context: bool = False,
         request_serializer: SerializationStrategy | None = None,
         result_serializer: SerializationStrategy | None = None,
         exception_serializer: SerializationStrategy | None = None,
+        polling_interval: float = 60,
     ) -> None:
         self._agent_id: AgentId[AgentT_co] | None = agent_id
         self._exchange = exchange
@@ -126,9 +134,20 @@ class Handle(Generic[AgentT_co]):
             uuid.UUID,
             asyncio.Future[Any],
         ] = {}
+        self._pending_actions: set[uuid.UUID] = set()
+        self._pending_actions_lock = asyncio.Lock()
 
         if self._exchange is not None:
             self._register_with_exchange(self._exchange)
+
+        # _agent_status is the private variable to keep track of the mailbox
+        # status in the polling loop --- it is not always current (based on
+        # when the last poll was), and is only updated if reject_on_inactive
+        # is true. For live mailbox stuts use `agent_status`
+        self._agent_status: MailboxStatus | None = None
+        self.polling_interval = polling_interval
+        self._reject_on_inactive: bool = False
+        self.reject_on_inactive = reject_on_inactive
 
     @property
     def agent_id(self) -> AgentId[AgentT_co]:
@@ -149,6 +168,28 @@ class Handle(Generic[AgentT_co]):
     def agent_id(self, value: AgentId[AgentT_co]) -> None:
         assert self._agent_id is None, 'Handle is already bound.'
         self._agent_id = value
+
+    @property
+    def reject_on_inactive(self) -> bool:
+        """Reject actions when agent is inactive."""
+        return self._reject_on_inactive
+
+    @reject_on_inactive.setter
+    def reject_on_inactive(self, value: bool) -> None:
+        old = self._reject_on_inactive
+        if not old and value:
+            # Start loop if needed
+            self._handle_ready = asyncio.Event()
+            self._reject_on_inactive = value  # Set after event to avoid race
+            self._status_task: asyncio.Task[None] = asyncio.create_task(
+                self._status_loop(),
+                name=f'{self.handle_id}-status-loop',
+            )
+        elif old and not value:
+            # Stop loop if not needed
+            self._reject_on_inactive = value  # Set before canel to avoid race
+            self._status_task.cancel()
+            self._agent_status = None
 
     @property
     def exchange(self) -> ExchangeClient[Any]:
@@ -190,11 +231,12 @@ class Handle(Generic[AgentT_co]):
 
         return (
             Handle,
-            (self._agent_id,),
+            (self._agent_id, self.reject_on_inactive),
             {
                 'request_serializer': self.request_serializer,
                 'result_serializer': self.result_serializer,
                 'exception_serializer': self.exception_serializer,
+                'polling_interval': self.polling_interval,
             },
         )
 
@@ -224,15 +266,88 @@ class Handle(Generic[AgentT_co]):
         return remote_method_call
 
     async def agent_stats(self) -> AgentStats:
-        """Return live exchange-level metrics for the remote agent.
-
-        Reads directly from the exchange state — no message round-trip.
-        """
+        """Return live exchange-level metrics for the remote agent."""
         return await self.exchange.agent_stats(self.agent_id)
+
+    async def agent_status(self) -> MailboxStatus:
+        """Return live status of the agent mailbox."""
+        status = await self.exchange.status(self.agent_id)
+        if self._reject_on_inactive:
+            # To avoid a situation where agent_status shows returns
+            # active, and actions are rejected with a stale status
+            await self._update_agent_status(status)
+
+        return status
+
+    async def _update_agent_status(self, status: MailboxStatus) -> None:
+        """Update _agent_status, notifying pending actions if needed."""
+        old_status = self._agent_status
+        self._agent_status = status
+        self._handle_ready.set()
+        if (
+            self._agent_status == MailboxStatus.INACTIVE
+            and self._agent_status != old_status
+        ):
+            await self._notify_pending_actions()
+
+    async def _status_loop(self) -> None:
+        """Poll exchange for agent status."""
+        while True:
+            if self._agent_id is not None:
+                with contextlib.suppress(ExchangeClientNotFoundError):
+                    status = await self.exchange.status(self.agent_id)
+                    await self._update_agent_status(status)
+
+            await asyncio.sleep(self.polling_interval)
+
+    async def _notify_pending_actions(self) -> None:
+        """Notify pending actions when agent becomes inactive."""
+        loop = asyncio.get_event_loop()
+
+        # Typically self._agent_status == INACTIVE should act as a lock, but
+        # while we are rejecting actions, the agent could become active
+        # and new actions could be added to the pending_actions set.
+        async with self._pending_actions_lock:
+            for response_tag in self._pending_actions:
+                cancel_request = Message.create(
+                    src=self.exchange.client_id,
+                    dest=self.agent_id,
+                    label=self.handle_id,
+                    body=CancelRequest(target_tag=response_tag),
+                )
+                logger.debug(
+                    'Cancelling action tag id %s',
+                    response_tag,
+                    extra=cancel_request.log_extra()
+                    | {
+                        'academy.action_state': 'cancelled',
+                    },
+                )
+                cancel_future: asyncio.Future[None] = loop.create_future()
+                self._pending_response_futures[cancel_request.tag] = (
+                    cancel_future
+                )
+                await self.exchange.send(cancel_request)
+
+                future = self._pending_response_futures[response_tag]
+                future.set_exception(AgentInactiveError(self.agent_id))
+
+    async def _check_status(self) -> None:
+        """Check if agent is inactive."""
+        if self._status_task.done() and self._status_task.exception():
+            raise RuntimeError(
+                'Error polling status of agent',
+            ) from self._status_task.exception()
+
+        await self._handle_ready.wait()
+        if self._agent_status == MailboxStatus.INACTIVE:
+            raise AgentInactiveError(self.agent_id)
 
     async def _process_response(self, response: Message[ResponseT]) -> None:
         future = self._pending_response_futures.pop(response.tag)
-        if not future.cancelled():
+        async with self._pending_actions_lock:
+            self._pending_actions.discard(response.tag)
+        if not future.done():
             future.set_result(response)
 
     def _register_with_exchange(self, exchange: ExchangeClient[Any]) -> None:
@@ -262,6 +377,9 @@ class Handle(Generic[AgentT_co]):
             AgentTerminatedError: If the agent's mailbox was closed. This
                 typically indicates the agent shutdown for another reason
                 (it self terminated or via another handle).
+            AgentInactiveError: If the agent is inactive (missed heartbeats)
+                and handle is configured to reject actions when agent is
+                inactive (reject_on_inactive=True)
             Exception: Any exception raised by the action.
         """
         tag_id = uuid.uuid4()
@@ -282,6 +400,9 @@ class Handle(Generic[AgentT_co]):
                 'academy.agent_id': self.agent_id,
             },
         )
+        if self.reject_on_inactive:
+            await self._check_status()
+
         exchange = self.exchange
         self._register_with_exchange(exchange)
         serialization = self.request_serializer or default_serializer.get()
@@ -303,6 +424,8 @@ class Handle(Generic[AgentT_co]):
         loop = asyncio.get_running_loop()
         future: asyncio.Future[Message[Response]] = loop.create_future()
         self._pending_response_futures[request.tag] = future
+        async with self._pending_actions_lock:
+            self._pending_actions.add(request.tag)
 
         try:
             logger.debug(
@@ -429,6 +552,12 @@ class Handle(Generic[AgentT_co]):
 
         if isinstance(body, ErrorResponse):
             raise body.get_exception()
+
+        if self.reject_on_inactive:
+            # A successful ping indicates active regaurdless of
+            # heartbeat, so we can use ping to wait for an agent
+            # to become active.
+            await self._update_agent_status(MailboxStatus.ACTIVE)
 
         elapsed = time.perf_counter() - start
         logger.debug(

--- a/academy/handle.py
+++ b/academy/handle.py
@@ -78,8 +78,6 @@ class Handle(Generic[AgentT_co]):
     Args:
         agent_id: ID of the remote agent, or ``None`` to defer
             binding (used by ``batch.queue()``).
-        reject_on_inactive: Return an error when target agent is inactive.
-            Needs to be a positional argument for serialization.
         exchange: A default exchange client to be used if an exchange client
             is not configured in the current context.
         ignore_context: Ignore the current context and force use of `exchange`
@@ -92,6 +90,7 @@ class Handle(Generic[AgentT_co]):
         exception_serializer: Strategy used to serialize results. If false-y,
             use the same strategy as the result serializer.
         polling_interval: Interval to poll exchange to see if agent is active.
+        reject_on_inactive: Return an error when target agent is inactive.
 
     Raises:
         ValueError: If `ignore_context=True` but `exchange` is not provided.
@@ -100,7 +99,6 @@ class Handle(Generic[AgentT_co]):
     def __init__(  # noqa: PLR0913
         self,
         agent_id: AgentId[AgentT_co] | None = None,
-        reject_on_inactive: bool = False,
         *,
         exchange: ExchangeClient[Any] | None = None,
         ignore_context: bool = False,
@@ -108,6 +106,7 @@ class Handle(Generic[AgentT_co]):
         result_serializer: SerializationStrategy | None = None,
         exception_serializer: SerializationStrategy | None = None,
         polling_interval: float = 60,
+        reject_on_inactive: bool = False,
     ) -> None:
         self._agent_id: AgentId[AgentT_co] | None = agent_id
         self._exchange = exchange
@@ -139,7 +138,7 @@ class Handle(Generic[AgentT_co]):
         # _agent_status is the private variable to keep track of the mailbox
         # status in the polling loop --- it is not always current (based on
         # when the last poll was), and is only updated if reject_on_inactive
-        # is true. For live mailbox stuts use `agent_status`
+        # is true. For live mailbox status use `agent_status`
         self._agent_status: MailboxStatus | None = None
         self.polling_interval = polling_interval
         self._reject_on_inactive: bool = False
@@ -175,7 +174,7 @@ class Handle(Generic[AgentT_co]):
         old = self._reject_on_inactive
         if not old and value:
             # Start loop if needed
-            self._handle_ready = asyncio.Event()
+            self._agent_status_set = asyncio.Event()
             self._reject_on_inactive = value  # Set after event to avoid race
             self._status_task: asyncio.Task[None] = asyncio.create_task(
                 self._status_loop(),
@@ -183,7 +182,7 @@ class Handle(Generic[AgentT_co]):
             )
         elif old and not value:
             # Stop loop if not needed
-            self._reject_on_inactive = value  # Set before canel to avoid race
+            self._reject_on_inactive = value  # Set before cancel to avoid race
             self._status_task.cancel()
             self._agent_status = None
 
@@ -227,12 +226,13 @@ class Handle(Generic[AgentT_co]):
 
         return (
             Handle,
-            (self._agent_id, self.reject_on_inactive),
+            (self._agent_id,),
             {
                 'request_serializer': self.request_serializer,
                 'result_serializer': self.result_serializer,
                 'exception_serializer': self.exception_serializer,
                 'polling_interval': self.polling_interval,
+                'reject_on_inactive': self.reject_on_inactive,
             },
         )
 
@@ -242,7 +242,9 @@ class Handle(Generic[AgentT_co]):
         This is necessary for unpickling to not treat set state as a
         remote action.
         """
+        reject_on_inactive: bool = state.pop('reject_on_inactive', False)
         self.__dict__.update(state)
+        self.reject_on_inactive = reject_on_inactive
 
     def __repr__(self) -> str:
         return (
@@ -279,7 +281,7 @@ class Handle(Generic[AgentT_co]):
         """Update _agent_status, notifying pending actions if needed."""
         old_status = self._agent_status
         self._agent_status = status
-        self._handle_ready.set()
+        self._agent_status_set.set()
         if (
             self._agent_status == MailboxStatus.INACTIVE
             and self._agent_status != old_status
@@ -304,16 +306,22 @@ class Handle(Generic[AgentT_co]):
         # while we are rejecting actions, the agent could become active
         # and new actions could be added to the pending_actions set.
         async with self._pending_actions_lock:
-            for response_tag in self._pending_actions:
+            for request_tag in self._pending_actions:
+                future = self._pending_response_futures[request_tag]
+                # If agents toggle back and forth between ACTIVE and INACTIVE
+                # the future might already be cancelled.
+                if future.done():
+                    continue
+
                 cancel_request = Message.create(
                     src=self.exchange.client_id,
                     dest=self.agent_id,
                     label=self.handle_id,
-                    body=CancelRequest(target_tag=response_tag),
+                    body=CancelRequest(target_tag=request_tag),
                 )
                 logger.debug(
                     'Cancelling action tag id %s',
-                    response_tag,
+                    request_tag,
                     extra=cancel_request.log_extra()
                     | {
                         'academy.action_state': 'cancelled',
@@ -324,8 +332,6 @@ class Handle(Generic[AgentT_co]):
                     cancel_future
                 )
                 await self.exchange.send(cancel_request)
-
-                future = self._pending_response_futures[response_tag]
                 future.set_exception(AgentInactiveError(self.agent_id))
 
     async def _check_status(self) -> None:
@@ -337,7 +343,7 @@ class Handle(Generic[AgentT_co]):
                 'Error polling status of agent',
             ) from self._status_task.exception()
 
-        await self._handle_ready.wait()
+        await self._agent_status_set.wait()
         if self._agent_status == MailboxStatus.INACTIVE:
             raise AgentInactiveError(self.agent_id)
 
@@ -552,7 +558,7 @@ class Handle(Generic[AgentT_co]):
             raise body.get_exception()
 
         if self.reject_on_inactive:
-            # A successful ping indicates active regaurdless of
+            # A successful ping indicates active regardless of
             # heartbeat, so we can use ping to wait for an agent
             # to become active.
             await self._update_agent_status(MailboxStatus.ACTIVE)
@@ -655,6 +661,7 @@ class ProxyHandle(Handle[AgentT]):
         self.agent = agent
         self._agent_id: AgentId[AgentT] = AgentId.new()
         self._agent_closed = False
+        self._reject_on_inactive = False
 
     def __repr__(self) -> str:
         return f'{type(self).__name__}(agent={self.agent!r})'

--- a/academy/handle.py
+++ b/academy/handle.py
@@ -6,7 +6,6 @@ import functools
 import logging
 import time
 import uuid
-from contextvars import ContextVar
 from pickle import PicklingError
 from typing import Any
 from typing import Generic
@@ -18,7 +17,8 @@ from weakref import WeakSet
 from academy.exception import AgentInactiveError
 from academy.exception import AgentTerminatedError
 from academy.exception import ExchangeClientNotFoundError
-from academy.exchange.transport import MailboxStatus
+from academy.exchange.client import exchange_context
+from academy.exchange.mailbox_status import MailboxStatus
 from academy.identifier import AgentId
 from academy.message import ActionRequest
 from academy.message import ActionResponse
@@ -49,10 +49,6 @@ logger = logging.getLogger(__name__)
 K = TypeVar('K')
 P = ParamSpec('P')
 R = TypeVar('R')
-
-exchange_context: ContextVar[ExchangeClient[Any]] = ContextVar(
-    'exchange_context',
-)
 
 
 class Handle(Generic[AgentT_co]):
@@ -334,7 +330,9 @@ class Handle(Generic[AgentT_co]):
 
     async def _check_status(self) -> None:
         """Check if agent is inactive."""
-        if self._status_task.done() and self._status_task.exception():
+        if (
+            self._status_task.done() and self._status_task.exception()
+        ):  # pragma: no cover
             raise RuntimeError(
                 'Error polling status of agent',
             ) from self._status_task.exception()

--- a/academy/manager.py
+++ b/academy/manager.py
@@ -24,9 +24,9 @@ from academy.debug import set_academy_debug
 from academy.exception import AgentTerminatedError
 from academy.exception import BadEntityIdError
 from academy.exception import raise_exceptions
+from academy.exchange.client import exchange_context
 from academy.exchange.transport import AgentRegistration
 from academy.exchange.transport import ExchangeTransportT
-from academy.handle import exchange_context
 from academy.handle import Handle
 from academy.identifier import AgentId
 from academy.identifier import EntityId

--- a/academy/runtime.py
+++ b/academy/runtime.py
@@ -31,9 +31,9 @@ from academy.context import AgentContext
 from academy.exception import ExchangeError
 from academy.exception import MailboxTerminatedError
 from academy.exception import raise_exceptions
+from academy.exchange.client import exchange_context
 from academy.exchange.transport import AgentRegistrationT
 from academy.exchange.transport import ExchangeTransportT
-from academy.handle import exchange_context
 from academy.identifier import EntityId
 from academy.message import AcademyErrorResponse
 from academy.message import ActionRequest

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -14,6 +14,8 @@ Please refer to our [Version Policy](version-policy.md) for more details on when
 
 ## Changes to Mailbox Status
 
+`MailboxStatus` has been moved from [`academy.exchange.client`][academy.exchange.client] to it's own file [`academy.exchange.status`][academy.exchange.status].
+
 The [`status()`][academy.exchange.client.ExchangeClient.status] method has been changed to add `MailboxStatus.INACTIVE` to give a specific status to agents which are still accepting messages but have missed a set number of heartbeats. You can adjust [`ExchangeClientConfig`][academy.exchange.client.ExchangeClientConfig] to change the heartbeat interval and the number of heartbeats until an agent is considered inactive. `ExchangeTransport.status` has been removed --- internally status is implemented by querying the heartbeat of the mailbox.
 
 ## Academy v0.5

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -14,7 +14,7 @@ Please refer to our [Version Policy](version-policy.md) for more details on when
 
 ## Changes to Mailbox Status
 
-`MailboxStatus` has been moved from [`academy.exchange.client`][academy.exchange.client] to it's own file [`academy.exchange.status`][academy.exchange.status].
+`MailboxStatus` has been moved from [`academy.exchange.client`][academy.exchange.client] to it's own file [`academy.exchange.status`][academy.exchange.mailbox_status].
 
 The [`status()`][academy.exchange.client.ExchangeClient.status] method has been changed to add `MailboxStatus.INACTIVE` to give a specific status to agents which are still accepting messages but have missed a set number of heartbeats. You can adjust [`ExchangeClientConfig`][academy.exchange.client.ExchangeClientConfig] to change the heartbeat interval and the number of heartbeats until an agent is considered inactive. `ExchangeTransport.status` has been removed --- internally status is implemented by querying the heartbeat of the mailbox.
 

--- a/tests/unit/exchange/client_test.py
+++ b/tests/unit/exchange/client_test.py
@@ -15,11 +15,11 @@ from academy.debug import set_academy_debug
 from academy.exception import BadEntityIdError
 from academy.exception import IncompatibleNetworkProtocolError
 from academy.exchange import ExchangeFactory
-from academy.exchange import MailboxStatus
 from academy.exchange import UserExchangeClient
 from academy.exchange.client import ExchangeClient
 from academy.exchange.client_config import ExchangeClientConfig
 from academy.exchange.local import LocalExchangeFactory
+from academy.exchange.mailbox_status import MailboxStatus
 from academy.handle import Handle
 from academy.identifier import AgentId
 from academy.identifier import UserId

--- a/tests/unit/exchange/cloud/backend_test.py
+++ b/tests/unit/exchange/cloud/backend_test.py
@@ -13,11 +13,11 @@ from academy.exception import BadEntityIdError
 from academy.exception import ForbiddenError
 from academy.exception import MailboxTerminatedError
 from academy.exception import MessageTooLargeError
-from academy.exchange import MailboxStatus
 from academy.exchange.cloud.backend import MailboxBackend
 from academy.exchange.cloud.backend import PythonBackend
 from academy.exchange.cloud.backend import RedisBackend
 from academy.exchange.cloud.client_info import ClientInfo
+from academy.exchange.mailbox_status import MailboxStatus
 from academy.identifier import AgentId
 from academy.identifier import UserId
 from academy.message import ErrorResponse

--- a/tests/unit/handle_test.py
+++ b/tests/unit/handle_test.py
@@ -799,7 +799,9 @@ async def test_handle_notifies_pending_messages_when_status_changes(
             mock_status.side_effect = [
                 MailboxStatus.ACTIVE,
                 MailboxStatus.INACTIVE,
+                MailboxStatus.ACTIVE,
                 MailboxStatus.INACTIVE,
+                MailboxStatus.ACTIVE,
                 MailboxStatus.INACTIVE,
             ]
             registration = await client.register_agent(SleepAgent)
@@ -808,7 +810,7 @@ async def test_handle_notifies_pending_messages_when_status_changes(
                 polling_interval=TEST_SLEEP_INTERVAL,
             )
             handle.reject_on_inactive = True
-            await handle._handle_ready.wait()
+            await handle._agent_status_set.wait()
             task = asyncio.create_task(handle.sleep(TEST_SLEEP_INTERVAL))
             await asyncio.sleep(0)
             assert len(handle._pending_actions) == 1  # Action was accepted
@@ -820,6 +822,12 @@ async def test_handle_notifies_pending_messages_when_status_changes(
             assert task.done()  # Task was notified
             with pytest.raises(AgentInactiveError):  # pragma: no cover
                 await task
+
+            await asyncio.sleep(
+                TEST_SLEEP_INTERVAL * 2,
+            )
+            # Toggling back and forth does not kill status loop
+            assert not handle._status_task.done()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/handle_test.py
+++ b/tests/unit/handle_test.py
@@ -11,6 +11,7 @@ from unittest import mock
 import pytest
 import pytest_asyncio
 
+from academy.exception import AgentInactiveError
 from academy.exception import AgentTerminatedError
 from academy.exception import DeserializationMethodProhibitedError
 from academy.exception import ExchangeClientNotFoundError
@@ -40,6 +41,7 @@ from academy.stats import AgentStats
 from testing.agents import CounterAgent
 from testing.agents import EmptyAgent
 from testing.agents import ErrorAgent
+from testing.agents import IdentityAgent
 from testing.agents import SleepAgent
 from testing.constant import TEST_SLEEP_INTERVAL
 
@@ -687,3 +689,165 @@ async def test_handle_exception_serializer(
         with pytest.raises(DeserializationMethodProhibitedError):
             await error_handle.fails()
         allowed_deserializers.reset(token)
+
+
+@pytest.mark.asyncio
+async def test_handle_agent_status(
+    exchange_client: UserExchangeClient[LocalExchangeTransport],
+) -> None:
+    registration = await exchange_client.register_agent(IdentityAgent)
+    handle = Handle(registration.agent_id)
+    assert await handle.agent_status() == MailboxStatus.INACTIVE
+
+
+@pytest.mark.asyncio
+async def test_handle_rejects_action_on_inactive(
+    exchange_client: UserExchangeClient[LocalExchangeTransport],
+) -> None:
+    registration = await exchange_client.register_agent(IdentityAgent)
+    handle = Handle(
+        registration.agent_id,
+        request_serializer=SerializationStrategy.PICKLE,
+        reject_on_inactive=True,
+    )
+
+    with pytest.raises(AgentInactiveError):
+        await handle.identity(1)
+
+
+@pytest.mark.asyncio
+async def test_handle_reject_on_inactive_setter(
+    manager: Manager[LocalExchangeTransport],
+) -> None:
+    hdl = await manager.launch(IdentityAgent)
+    hdl.reject_on_inactive = True
+    assert not hdl._status_task.done()
+
+    hdl.reject_on_inactive = False
+    await asyncio.sleep(0)
+    assert hdl._status_task.cancelled()
+
+
+@pytest.mark.asyncio
+async def test_handle_rejct_on_inactive_allows_on_active(
+    manager: Manager[LocalExchangeTransport],
+) -> None:
+    hdl = await manager.launch(IdentityAgent)
+    hdl.polling_interval = TEST_SLEEP_INTERVAL
+    hdl.reject_on_inactive = True  # Start fast polling loop
+
+    await asyncio.sleep(2 * TEST_SLEEP_INTERVAL)
+    assert await hdl.identity(1) == 1
+
+
+@pytest.mark.asyncio
+async def test_handle_ping_sets_active_status(
+    manager: Manager[LocalExchangeTransport],
+) -> None:
+    registration = await manager.register_agent(IdentityAgent)
+    handle = Handle(
+        registration.agent_id,
+        reject_on_inactive=True,
+        polling_interval=100000,
+    )
+    with pytest.raises(AgentInactiveError):
+        await handle.identity(1)
+
+    await manager.launch(IdentityAgent, registration=registration)
+
+    # Status should still be inactive because of long polling interval
+    with pytest.raises(AgentInactiveError):
+        await handle.identity(1)
+
+    await handle.ping()
+    assert await handle.identity(1) == 1
+
+
+@pytest.mark.asyncio
+async def test_handle_agent_status_sets_active_status(
+    manager: Manager[LocalExchangeTransport],
+) -> None:
+    registration = await manager.register_agent(IdentityAgent)
+    handle = Handle(
+        registration.agent_id,
+        reject_on_inactive=True,
+        polling_interval=100000,
+    )
+    with pytest.raises(AgentInactiveError):
+        await handle.identity(1)
+
+    await manager.launch(IdentityAgent, registration=registration)
+
+    # Status should still be inactive because of long polling interval
+    with pytest.raises(AgentInactiveError):
+        await handle.identity(1)
+
+    status = await handle.agent_status()
+    while status != MailboxStatus.ACTIVE:
+        await asyncio.sleep(TEST_SLEEP_INTERVAL)
+        status = await handle.agent_status()
+
+    assert await handle.identity(1) == 1
+
+
+@pytest.mark.asyncio
+async def test_handle_notifies_pending_messages_when_status_changes(
+    local_exchange_factory: LocalExchangeFactory,
+) -> None:
+    async with await local_exchange_factory.create_user_client() as client:
+        with mock.patch.object(client, 'status') as mock_status:
+            mock_status.side_effect = [
+                MailboxStatus.ACTIVE,
+                MailboxStatus.INACTIVE,
+                MailboxStatus.INACTIVE,
+                MailboxStatus.INACTIVE,
+            ]
+            registration = await client.register_agent(SleepAgent)
+            handle = Handle(
+                registration.agent_id,
+                polling_interval=TEST_SLEEP_INTERVAL,
+            )
+            handle.reject_on_inactive = True
+            await handle._handle_ready.wait()
+            task = asyncio.create_task(handle.sleep(TEST_SLEEP_INTERVAL))
+            await asyncio.sleep(0)
+            assert len(handle._pending_actions) == 1  # Action was accepted
+            assert not task.done()
+
+            await asyncio.sleep(
+                TEST_SLEEP_INTERVAL * 2,
+            )  # Agent becomes inactive
+            assert task.done()  # Task was notified
+            with pytest.raises(AgentInactiveError):
+                await task
+
+
+@pytest.mark.asyncio
+async def test_handle_status_loop_no_agent_id():
+    hdl: Handle[Any] = Handle(reject_on_inactive=True)
+    await asyncio.sleep(0)
+    assert not hdl._status_task.done()
+
+
+@pytest.mark.asyncio
+async def test_handle_status_loop_no_exchange_client():
+    hdl: Handle[Any] = Handle(AgentId.new(), reject_on_inactive=True)
+    await asyncio.sleep(0)
+    assert not hdl._status_task.done()
+
+
+@pytest.mark.asyncio
+async def test_handle_serialize_restarts_status_loop(
+    exchange_client: UserExchangeClient[LocalExchangeTransport],
+) -> None:
+    registration = await exchange_client.register_agent(EmptyAgent)
+    handle = Handle(
+        registration.agent_id,
+        reject_on_inactive=True,
+    )
+    assert handle.reject_on_inactive
+    assert not handle._status_task.done()
+
+    reconstructed = pickle.loads(pickle.dumps(handle))
+    assert reconstructed.reject_on_inactive
+    assert not reconstructed._status_task.done()

--- a/tests/unit/handle_test.py
+++ b/tests/unit/handle_test.py
@@ -18,10 +18,10 @@ from academy.exception import ExchangeClientNotFoundError
 from academy.exchange import LocalExchangeFactory
 from academy.exchange import LocalExchangeTransport
 from academy.exchange import UserExchangeClient
+from academy.exchange.client import exchange_context
 from academy.exchange.cloud.client import HttpExchangeFactory
 from academy.exchange.factory import ExchangeFactory
-from academy.exchange.transport import MailboxStatus
-from academy.handle import exchange_context
+from academy.exchange.mailbox_status import MailboxStatus
 from academy.handle import Handle
 from academy.handle import ProxyHandle
 from academy.identifier import AgentId
@@ -783,7 +783,7 @@ async def test_handle_agent_status_sets_active_status(
         await handle.identity(1)
 
     status = await handle.agent_status()
-    while status != MailboxStatus.ACTIVE:
+    while status != MailboxStatus.ACTIVE:  # pragma: no cover
         await asyncio.sleep(TEST_SLEEP_INTERVAL)
         status = await handle.agent_status()
 
@@ -818,7 +818,7 @@ async def test_handle_notifies_pending_messages_when_status_changes(
                 TEST_SLEEP_INTERVAL * 2,
             )  # Agent becomes inactive
             assert task.done()  # Task was notified
-            with pytest.raises(AgentInactiveError):
+            with pytest.raises(AgentInactiveError):  # pragma: no cover
                 await task
 
 

--- a/tests/unit/runtime_test.py
+++ b/tests/unit/runtime_test.py
@@ -22,7 +22,7 @@ from academy.exchange import LocalExchangeTransport
 from academy.exchange import UserExchangeClient
 from academy.exchange.cloud.client import HttpExchangeFactory
 from academy.exchange.cloud.client import HttpExchangeTransport
-from academy.exchange.transport import MailboxStatus
+from academy.exchange.mailbox_status import MailboxStatus
 from academy.handle import Handle
 from academy.handle import ProxyHandle
 from academy.identifier import AgentId


### PR DESCRIPTION
## Summary
<!--- Provide a summary of the changes --->
There are many times where you do not want to put a message in the mailbox of an agent that's not online (for instance the agent died unexpectedly and you expect it to be online, the agent may be functioning properly but you don't want to wait for it to be online, etc.). Building off heartbeats (#366) and the new inactive status (#404), this PR adds an option to a handle to  raise an error on the client side calling the action if the agent is "INACTIVE". For this PR, we poll the exchange separately from the message listening loop.


## Related Issues
<!--- List any issue numbers above that this PR addresses --->
 - Not an open issue, but this came up in the StuctBioReasoner work 

## Changes
<!--- Check which of the following changes were made --->

- [ ] Breaking (backwards incompatible changes to public interfaces)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change or feature addition)
- [ ] Refactor (internal code or design clean up)
- [ ] Documentation (no changes to the code)
- [ ] Test (changes or additions to testing)
- [ ] Build (change to CI workflows or build processes)
- [ ] Package (changes to package metadata or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

N/A

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added based on the types of changes.
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [ ] Docs have been updated and reviewed if relevant.
