### PR TITLE
Add Retry Loop To Http Client

### DIFF
--- a/academy/exchange/cloud/app.py
+++ b/academy/exchange/cloud/app.py
@@ -62,9 +62,8 @@ from academy.exchange.cloud.authenticate import get_authenticator
 from academy.exchange.cloud.backend import MailboxBackend
 from academy.exchange.cloud.client_info import ClientInfo
 from academy.exchange.cloud.config import ExchangeServingConfig
-from academy.exchange.mailbox_status import MailboxStatus
 from academy.exchange.cloud.status import StatusCode
-from academy.exchange.transport import MailboxStatus
+from academy.exchange.mailbox_status import MailboxStatus
 from academy.identifier import EntityId
 from academy.message import Message
 

--- a/academy/exchange/cloud/app.py
+++ b/academy/exchange/cloud/app.py
@@ -62,12 +62,9 @@ from academy.exchange.cloud.authenticate import get_authenticator
 from academy.exchange.cloud.backend import MailboxBackend
 from academy.exchange.cloud.client_info import ClientInfo
 from academy.exchange.cloud.config import ExchangeServingConfig
-<<<<<<< HEAD
 from academy.exchange.mailbox_status import MailboxStatus
-=======
 from academy.exchange.cloud.status import StatusCode
 from academy.exchange.transport import MailboxStatus
->>>>>>> fc8156a (Adding retry options to http client)
 from academy.identifier import EntityId
 from academy.message import Message
 

--- a/academy/exchange/cloud/app.py
+++ b/academy/exchange/cloud/app.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 
 import argparse
 import dataclasses
-import enum
 import functools
 import logging
 import ssl
@@ -63,25 +62,16 @@ from academy.exchange.cloud.authenticate import get_authenticator
 from academy.exchange.cloud.backend import MailboxBackend
 from academy.exchange.cloud.client_info import ClientInfo
 from academy.exchange.cloud.config import ExchangeServingConfig
+<<<<<<< HEAD
 from academy.exchange.mailbox_status import MailboxStatus
+=======
+from academy.exchange.cloud.status import StatusCode
+from academy.exchange.transport import MailboxStatus
+>>>>>>> fc8156a (Adding retry options to http client)
 from academy.identifier import EntityId
 from academy.message import Message
 
 logger = logging.getLogger(__name__)
-
-
-class StatusCode(enum.Enum):
-    """Http status codes."""
-
-    OKAY = 200
-    BAD_REQUEST = 400
-    UNAUTHORIZED = 401
-    FORBIDDEN = 403
-    NOT_FOUND = 404
-    TIMEOUT = 408
-    TOO_LARGE = 413
-    TERMINATED = 419
-    NO_RESPONSE = 444
 
 
 MANAGER_KEY = AppKey('manager', MailboxBackend)

--- a/academy/exchange/cloud/client.py
+++ b/academy/exchange/cloud/client.py
@@ -23,6 +23,7 @@ else:  # pragma: <3.11 cover
     from typing_extensions import Self
 
 import aiohttp
+import aiohttp.web
 from aiohttp import ClientResponse
 from aiohttp import hdrs
 from pydantic import BaseModel
@@ -34,10 +35,10 @@ from academy.exception import MailboxTerminatedError
 from academy.exception import UnauthorizedError
 from academy.exchange.client_config import ExchangeClientConfig
 from academy.exchange.cloud.app import _run
-from academy.exchange.cloud.app import StatusCode
 from academy.exchange.cloud.config import ExchangeServingConfig
 from academy.exchange.cloud.config import LogConfig
 from academy.exchange.cloud.login import get_auth_headers
+from academy.exchange.cloud.status import StatusCode
 from academy.exchange.factory import ExchangeFactory
 from academy.exchange.transport import ExchangeTransportMixin
 from academy.identifier import AgentId
@@ -65,6 +66,8 @@ class _HttpConnectionInfo(NamedTuple):
     ssl_verify: bool | None = None
     request_timeout_s: float = 60
     client_timeout: aiohttp.ClientTimeout | None = None
+    retries: int = 0
+    initial_retry_backoff: float = 1.0
 
 
 class HttpAgentRegistration(BaseModel, Generic[AgentT]):
@@ -185,13 +188,16 @@ class HttpExchangeTransport(ExchangeTransportMixin, NoPickleMixin):
         return self._mailbox_id
 
     @contextlib.asynccontextmanager
-    async def _request_with_refresh(
+    async def _request_with_retry(
         self,
         method: str,
         url: str,
         **kwargs: Any,
     ) -> AsyncGenerator[ClientResponse]:
-        """Make request, refreshing token if ForbiddenError is returned.
+        """Make request with retries.
+
+        This retries on a transient error, or if there is a forbidden error,
+        attempts to reauth, then performs the request.
 
         Note:
             This is to simplify the case where users are running on a shared
@@ -208,20 +214,46 @@ class HttpExchangeTransport(ExchangeTransportMixin, NoPickleMixin):
             url: Destination of request
             **kwargs: Additional arguments to aiohttp.ClientSession.request
         """
-        retry = True
-        while True:
-            async with self._session.request(
-                method,
-                url,
-                **kwargs,
-            ) as response:
-                if response.status == StatusCode.FORBIDDEN.value and retry:
-                    retry = False
+        n_attempts = self._info.retries + 1
+        retry_backoff = self._info.initial_retry_backoff
+        have_reauthenticated = False
+        while n_attempts > 0:
+            n_attempts -= 1
+            try:
+                response = await self._session.request(
+                    method,
+                    url,
+                    **kwargs,
+                )
+            except BaseException as exc:
+                logger.exception(exc)
+                if n_attempts > 0 and _is_transient_error(exc):
+                    await asyncio.sleep(retry_backoff)
+                    retry_backoff *= 2
+                    continue
+                raise exc
+
+            try:
+                response.raise_for_status()
+            except BaseException as exc:
+                if (
+                    isinstance(exc, aiohttp.ClientResponseError)
+                    and exc.status == StatusCode.FORBIDDEN.value
+                ) and not have_reauthenticated:
                     auth_headers = get_auth_headers(self._auth_method)
                     self._info.additional_headers.update(auth_headers)
                     self._session = self.create_session(self._info)
+                    n_attempts = self._info.retries + 1
+                    retry_backoff = self._info.initial_retry_backoff
+                    have_reauthenticated = True
                     continue
-                yield response
+
+                if n_attempts > 0 and _is_transient_error(exc):
+                    await asyncio.sleep(retry_backoff)
+                    retry_backoff *= 2
+                    continue
+
+            yield response
             break
 
     async def close(self) -> None:
@@ -239,7 +271,7 @@ class HttpExchangeTransport(ExchangeTransportMixin, NoPickleMixin):
         else:
             agent_str = f'{agent.__module__}.{agent.__name__}'
 
-        async with self._request_with_refresh(
+        async with self._request_with_retry(
             'get',
             self._discover_url,
             json={
@@ -262,6 +294,8 @@ class HttpExchangeTransport(ExchangeTransportMixin, NoPickleMixin):
             ssl_verify=self._info.ssl_verify,
             request_timeout_s=self._info.request_timeout_s,
             client_timeout=self._info.client_timeout,
+            retries=self._info.retries,
+            initial_retry_backoff=self._info.initial_retry_backoff,
         )
 
     async def parse(self, raw_lines: list[str]) -> Message[Any] | None:
@@ -318,7 +352,7 @@ class HttpExchangeTransport(ExchangeTransportMixin, NoPickleMixin):
             if internal_timeout <= 0:
                 raise TimeoutError()
 
-            async with self._request_with_refresh(
+            async with self._request_with_retry(
                 'get',
                 self._listen_url,
                 json={
@@ -356,7 +390,7 @@ class HttpExchangeTransport(ExchangeTransportMixin, NoPickleMixin):
         name: str | None = None,
     ) -> HttpAgentRegistration[AgentT]:
         aid: AgentId[AgentT] = AgentId.new(name=name)
-        async with self._request_with_refresh(
+        async with self._request_with_retry(
             'post',
             self._mailbox_url,
             json={
@@ -368,7 +402,7 @@ class HttpExchangeTransport(ExchangeTransportMixin, NoPickleMixin):
         return HttpAgentRegistration(agent_id=aid)
 
     async def send(self, message: Message[Any]) -> None:
-        async with self._request_with_refresh(
+        async with self._request_with_retry(
             'put',
             self._message_url,
             json={'message': message.model_dump_json()},
@@ -376,7 +410,7 @@ class HttpExchangeTransport(ExchangeTransportMixin, NoPickleMixin):
             _raise_for_status(response, self.mailbox_id, message.dest)
 
     async def terminate(self, uid: EntityId) -> None:
-        async with self._request_with_refresh(
+        async with self._request_with_retry(
             'delete',
             self._mailbox_url,
             json={'mailbox': uid.model_dump_json()},
@@ -384,7 +418,7 @@ class HttpExchangeTransport(ExchangeTransportMixin, NoPickleMixin):
             _raise_for_status(response, self.mailbox_id, uid)
 
     async def update_heartbeat(self) -> None:
-        async with self._request_with_refresh(
+        async with self._request_with_retry(
             'post',
             self._heartbeat_url,
             json={'mailbox': self.mailbox_id.model_dump_json()},
@@ -392,7 +426,7 @@ class HttpExchangeTransport(ExchangeTransportMixin, NoPickleMixin):
             _raise_for_status(response, self.mailbox_id)
 
     async def heartbeat_status(self, uid: EntityId) -> float | None:
-        async with self._request_with_refresh(
+        async with self._request_with_retry(
             'get',
             self._heartbeat_url,
             json={'mailbox': uid.model_dump_json()},
@@ -401,7 +435,7 @@ class HttpExchangeTransport(ExchangeTransportMixin, NoPickleMixin):
             return (await response.json())['heartbeat']
 
     async def agent_stats(self, uid: EntityId) -> AgentStats:
-        async with self._request_with_refresh(
+        async with self._request_with_retry(
             'get',
             f'{self._info.url}/mailbox/stats',
             json={'mailbox': uid.model_dump_json()},
@@ -475,13 +509,16 @@ class HttpExchangeConsole:
         return cls(session, connection_info, auth_method)
 
     @contextlib.asynccontextmanager
-    async def _request_with_refresh(
+    async def _request_with_retry(
         self,
         method: str,
         url: str,
         **kwargs: Any,
     ) -> AsyncGenerator[ClientResponse]:
-        """Make request, refreshing token if ForbiddenError is returned.
+        """Make request with retries.
+
+        This retries on a transient error, or if there is a forbidden error,
+        attempts to reauth, then performs the request.
 
         Note:
             This is to simplify the case where users are running on a shared
@@ -498,21 +535,47 @@ class HttpExchangeConsole:
             url: Destination of request
             **kwargs: Additional arguments to aiohttp.ClientSession.request
         """
-        retry = True
-        while True:
-            async with self._session.request(
-                method,
-                url,
-                **kwargs,
-            ) as response:
-                if response.status == StatusCode.FORBIDDEN.value and retry:
-                    retry = False
+        n_attempts = self._info.retries + 1
+        retry_backoff = self._info.initial_retry_backoff
+        have_reauthenticated = False
+        while n_attempts > 0:
+            n_attempts -= 1
+            try:
+                response = await self._session.request(
+                    method,
+                    url,
+                    **kwargs,
+                )
+            except BaseException as exc:
+                logger.exception(exc)
+                if n_attempts > 0 and _is_transient_error(exc):
+                    await asyncio.sleep(retry_backoff)
+                    retry_backoff *= 2
+                    continue
+                raise exc
+
+            try:
+                response.raise_for_status()
+            except BaseException as exc:
+                if (
+                    isinstance(exc, aiohttp.ClientResponseError)
+                    and exc.status == StatusCode.FORBIDDEN.value
+                ) and not have_reauthenticated:
                     auth_headers = get_auth_headers(self._auth_method)
                     self._info.additional_headers.update(auth_headers)
                     self._session = self.create_session(self._info)
+                    n_attempts = self._info.retries + 1
+                    retry_backoff = self._info.initial_retry_backoff
+                    have_reauthenticated = True
                     continue
-                yield response
-                break
+
+                if n_attempts > 0 and _is_transient_error(exc):
+                    await asyncio.sleep(retry_backoff)
+                    retry_backoff *= 2
+                    continue
+
+            yield response
+            break
 
     def factory(self) -> HttpExchangeFactory:
         # Note: When getting factory, auth method is not preserved
@@ -524,6 +587,8 @@ class HttpExchangeConsole:
             ssl_verify=self._info.ssl_verify,
             request_timeout_s=self._info.request_timeout_s,
             client_timeout=self._info.client_timeout,
+            retries=self._info.retries,
+            initial_retry_backoff=self._info.initial_retry_backoff,
         )
 
     async def share_mailbox(
@@ -538,7 +603,7 @@ class HttpExchangeConsole:
             group_id: Id of globus group. User must be part of group to share
                 mailbox.
         """
-        async with self._request_with_refresh(
+        async with self._request_with_retry(
             'post',
             self._share_url,
             json={
@@ -554,7 +619,7 @@ class HttpExchangeConsole:
         Args:
             mailbox_id: Either AgentId or UserId of mailbox
         """
-        async with self._request_with_refresh(
+        async with self._request_with_retry(
             'get',
             self._share_url,
             json={
@@ -577,7 +642,7 @@ class HttpExchangeConsole:
             group_id: Id of globus group. User must be part of group to share
                 mailbox.
         """
-        async with self._request_with_refresh(
+        async with self._request_with_retry(
             'delete',
             self._share_url,
             json={
@@ -612,6 +677,10 @@ class HttpExchangeFactory(ExchangeFactory[HttpExchangeTransport]):
             long-lived SSE listen connections are not severed mid-stream.
             Pass a custom [`aiohttp.ClientTimeout`][aiohttp.ClientTimeout] to
             override.
+        retries: Number of times to retry transient error messages received
+            from the exchange server.
+        initial_retry_backoff: Seconds to wait before retrying. Retry is
+            exponential from the initial amount.
     """
 
     def __init__(  # noqa: PLR0913
@@ -624,6 +693,8 @@ class HttpExchangeFactory(ExchangeFactory[HttpExchangeTransport]):
         ssl_verify: bool | None = None,
         client_timeout: aiohttp.ClientTimeout | None = None,
         config: ExchangeClientConfig | None = None,
+        retries: int = 1,
+        initial_retry_backoff: float = 1,
     ) -> None:
         super().__init__(config)
 
@@ -649,6 +720,8 @@ class HttpExchangeFactory(ExchangeFactory[HttpExchangeTransport]):
             ssl_verify=ssl_verify,
             request_timeout_s=request_timeout_s,
             client_timeout=client_timeout,
+            retries=retries,
+            initial_retry_backoff=initial_retry_backoff,
         )
         self._auth_method = auth_method
 
@@ -671,6 +744,29 @@ class HttpExchangeFactory(ExchangeFactory[HttpExchangeTransport]):
             connection_info=self._info,
             auth_method=self._auth_method,
         )
+
+
+TRANSIENT_STATUSES = frozenset({429, 500, 502, 503, 504})
+
+
+def _is_transient_error(exc: BaseException) -> bool:
+    if isinstance(
+        exc,
+        (
+            aiohttp.ClientConnectionError,
+            aiohttp.ClientPayloadError,
+            OSError,
+            # ``asyncio.TimeoutError`` is an alias of the builtin
+            # ``TimeoutError`` on Python >= 3.11 which is covered in
+            # OSError; list both so the predicate behaves the same
+            # on 3.10.
+            asyncio.TimeoutError,
+        ),
+    ):
+        return True
+    elif isinstance(exc, aiohttp.ClientResponseError):
+        return exc.status in TRANSIENT_STATUSES
+    return False
 
 
 def _raise_for_status(

--- a/academy/exchange/cloud/client.py
+++ b/academy/exchange/cloud/client.py
@@ -23,7 +23,6 @@ else:  # pragma: <3.11 cover
     from typing_extensions import Self
 
 import aiohttp
-import aiohttp.web
 from aiohttp import ClientResponse
 from aiohttp import hdrs
 from pydantic import BaseModel

--- a/academy/exchange/cloud/client.py
+++ b/academy/exchange/cloud/client.py
@@ -188,16 +188,13 @@ class HttpExchangeTransport(ExchangeTransportMixin, NoPickleMixin):
         return self._mailbox_id
 
     @contextlib.asynccontextmanager
-    async def _request_with_retry(
+    async def _request_with_retry_and_refresh(
         self,
         method: str,
         url: str,
         **kwargs: Any,
     ) -> AsyncGenerator[ClientResponse]:
-        """Make request with retries.
-
-        This retries on a transient error, or if there is a forbidden error,
-        attempts to reauth, then performs the request.
+        """Make request, refreshing token if ForbiddenError is returned.
 
         Note:
             This is to simplify the case where users are running on a shared
@@ -214,46 +211,23 @@ class HttpExchangeTransport(ExchangeTransportMixin, NoPickleMixin):
             url: Destination of request
             **kwargs: Additional arguments to aiohttp.ClientSession.request
         """
-        n_attempts = self._info.retries + 1
-        retry_backoff = self._info.initial_retry_backoff
-        have_reauthenticated = False
-        while n_attempts > 0:
-            n_attempts -= 1
-            try:
-                response = await self._session.request(
-                    method,
-                    url,
-                    **kwargs,
-                )
-            except BaseException as exc:
-                logger.exception(exc)
-                if n_attempts > 0 and _is_transient_error(exc):
-                    await asyncio.sleep(retry_backoff)
-                    retry_backoff *= 2
-                    continue
-                raise exc
-
-            try:
-                response.raise_for_status()
-            except BaseException as exc:
-                if (
-                    isinstance(exc, aiohttp.ClientResponseError)
-                    and exc.status == StatusCode.FORBIDDEN.value
-                ) and not have_reauthenticated:
+        retry = True
+        while True:
+            async with _request_with_retry(
+                self._session,
+                method,
+                url,
+                retries=self._info.retries,
+                retry_backoff=self._info.initial_retry_backoff,
+                **kwargs,
+            ) as response:
+                if response.status == StatusCode.FORBIDDEN.value and retry:
+                    retry = False
                     auth_headers = get_auth_headers(self._auth_method)
                     self._info.additional_headers.update(auth_headers)
                     self._session = self.create_session(self._info)
-                    n_attempts = self._info.retries + 1
-                    retry_backoff = self._info.initial_retry_backoff
-                    have_reauthenticated = True
                     continue
-
-                if n_attempts > 0 and _is_transient_error(exc):
-                    await asyncio.sleep(retry_backoff)
-                    retry_backoff *= 2
-                    continue
-
-            yield response
+                yield response
             break
 
     async def close(self) -> None:
@@ -271,7 +245,7 @@ class HttpExchangeTransport(ExchangeTransportMixin, NoPickleMixin):
         else:
             agent_str = f'{agent.__module__}.{agent.__name__}'
 
-        async with self._request_with_retry(
+        async with self._request_with_retry_and_refresh(
             'get',
             self._discover_url,
             json={
@@ -352,7 +326,7 @@ class HttpExchangeTransport(ExchangeTransportMixin, NoPickleMixin):
             if internal_timeout <= 0:
                 raise TimeoutError()
 
-            async with self._request_with_retry(
+            async with self._request_with_retry_and_refresh(
                 'get',
                 self._listen_url,
                 json={
@@ -390,7 +364,7 @@ class HttpExchangeTransport(ExchangeTransportMixin, NoPickleMixin):
         name: str | None = None,
     ) -> HttpAgentRegistration[AgentT]:
         aid: AgentId[AgentT] = AgentId.new(name=name)
-        async with self._request_with_retry(
+        async with self._request_with_retry_and_refresh(
             'post',
             self._mailbox_url,
             json={
@@ -402,7 +376,7 @@ class HttpExchangeTransport(ExchangeTransportMixin, NoPickleMixin):
         return HttpAgentRegistration(agent_id=aid)
 
     async def send(self, message: Message[Any]) -> None:
-        async with self._request_with_retry(
+        async with self._request_with_retry_and_refresh(
             'put',
             self._message_url,
             json={'message': message.model_dump_json()},
@@ -410,7 +384,7 @@ class HttpExchangeTransport(ExchangeTransportMixin, NoPickleMixin):
             _raise_for_status(response, self.mailbox_id, message.dest)
 
     async def terminate(self, uid: EntityId) -> None:
-        async with self._request_with_retry(
+        async with self._request_with_retry_and_refresh(
             'delete',
             self._mailbox_url,
             json={'mailbox': uid.model_dump_json()},
@@ -418,7 +392,7 @@ class HttpExchangeTransport(ExchangeTransportMixin, NoPickleMixin):
             _raise_for_status(response, self.mailbox_id, uid)
 
     async def update_heartbeat(self) -> None:
-        async with self._request_with_retry(
+        async with self._request_with_retry_and_refresh(
             'post',
             self._heartbeat_url,
             json={'mailbox': self.mailbox_id.model_dump_json()},
@@ -426,7 +400,7 @@ class HttpExchangeTransport(ExchangeTransportMixin, NoPickleMixin):
             _raise_for_status(response, self.mailbox_id)
 
     async def heartbeat_status(self, uid: EntityId) -> float | None:
-        async with self._request_with_retry(
+        async with self._request_with_retry_and_refresh(
             'get',
             self._heartbeat_url,
             json={'mailbox': uid.model_dump_json()},
@@ -435,7 +409,7 @@ class HttpExchangeTransport(ExchangeTransportMixin, NoPickleMixin):
             return (await response.json())['heartbeat']
 
     async def agent_stats(self, uid: EntityId) -> AgentStats:
-        async with self._request_with_retry(
+        async with self._request_with_retry_and_refresh(
             'get',
             f'{self._info.url}/mailbox/stats',
             json={'mailbox': uid.model_dump_json()},
@@ -509,16 +483,13 @@ class HttpExchangeConsole:
         return cls(session, connection_info, auth_method)
 
     @contextlib.asynccontextmanager
-    async def _request_with_retry(
+    async def _request_with_retry_and_refresh(
         self,
         method: str,
         url: str,
         **kwargs: Any,
     ) -> AsyncGenerator[ClientResponse]:
-        """Make request with retries.
-
-        This retries on a transient error, or if there is a forbidden error,
-        attempts to reauth, then performs the request.
+        """Make request, refreshing token if ForbiddenError is returned.
 
         Note:
             This is to simplify the case where users are running on a shared
@@ -535,46 +506,23 @@ class HttpExchangeConsole:
             url: Destination of request
             **kwargs: Additional arguments to aiohttp.ClientSession.request
         """
-        n_attempts = self._info.retries + 1
-        retry_backoff = self._info.initial_retry_backoff
-        have_reauthenticated = False
-        while n_attempts > 0:
-            n_attempts -= 1
-            try:
-                response = await self._session.request(
-                    method,
-                    url,
-                    **kwargs,
-                )
-            except BaseException as exc:
-                logger.exception(exc)
-                if n_attempts > 0 and _is_transient_error(exc):
-                    await asyncio.sleep(retry_backoff)
-                    retry_backoff *= 2
-                    continue
-                raise exc
-
-            try:
-                response.raise_for_status()
-            except BaseException as exc:
-                if (
-                    isinstance(exc, aiohttp.ClientResponseError)
-                    and exc.status == StatusCode.FORBIDDEN.value
-                ) and not have_reauthenticated:
+        retry = True
+        while True:
+            async with _request_with_retry(
+                self._session,
+                method,
+                url,
+                retries=self._info.retries,
+                retry_backoff=self._info.initial_retry_backoff,
+                **kwargs,
+            ) as response:
+                if response.status == StatusCode.FORBIDDEN.value and retry:
+                    retry = False
                     auth_headers = get_auth_headers(self._auth_method)
                     self._info.additional_headers.update(auth_headers)
                     self._session = self.create_session(self._info)
-                    n_attempts = self._info.retries + 1
-                    retry_backoff = self._info.initial_retry_backoff
-                    have_reauthenticated = True
                     continue
-
-                if n_attempts > 0 and _is_transient_error(exc):
-                    await asyncio.sleep(retry_backoff)
-                    retry_backoff *= 2
-                    continue
-
-            yield response
+                yield response
             break
 
     def factory(self) -> HttpExchangeFactory:
@@ -603,7 +551,7 @@ class HttpExchangeConsole:
             group_id: Id of globus group. User must be part of group to share
                 mailbox.
         """
-        async with self._request_with_retry(
+        async with self._request_with_retry_and_refresh(
             'post',
             self._share_url,
             json={
@@ -619,7 +567,7 @@ class HttpExchangeConsole:
         Args:
             mailbox_id: Either AgentId or UserId of mailbox
         """
-        async with self._request_with_retry(
+        async with self._request_with_retry_and_refresh(
             'get',
             self._share_url,
             json={
@@ -642,7 +590,7 @@ class HttpExchangeConsole:
             group_id: Id of globus group. User must be part of group to share
                 mailbox.
         """
-        async with self._request_with_retry(
+        async with self._request_with_retry_and_refresh(
             'delete',
             self._share_url,
             json={
@@ -747,6 +695,57 @@ class HttpExchangeFactory(ExchangeFactory[HttpExchangeTransport]):
 
 
 TRANSIENT_STATUSES = frozenset({429, 500, 502, 503, 504})
+
+
+@contextlib.asynccontextmanager
+async def _request_with_retry(
+    session: aiohttp.ClientSession,
+    method: str,
+    url: str,
+    retries: int,
+    retry_backoff: float,
+    **kwargs: Any,
+) -> AsyncGenerator[ClientResponse]:
+    """Make request with retries.
+
+    This retries on a transient error.
+
+    Args:
+        session: Session used to make requests
+        method: Http method to call
+        url: Destination of request
+        retries: Number of times to retry the request
+        retry_backoff: Time in seconds between retries. Exponential backoff
+            between retries.
+        **kwargs: Additional arguments to aiohttp.ClientSession.request
+    """
+    n_attempts = retries + 1
+    while True:
+        n_attempts -= 1
+        try:
+            response = await session.request(
+                method,
+                url,
+                **kwargs,
+            )
+        except BaseException as exc:
+            logger.exception(exc)
+            if n_attempts > 0 and _is_transient_error(exc):
+                await asyncio.sleep(retry_backoff)
+                retry_backoff *= 2
+                continue
+            raise exc
+
+        try:
+            response.raise_for_status()
+        except BaseException as exc:
+            if n_attempts > 0 and _is_transient_error(exc):
+                await asyncio.sleep(retry_backoff)
+                retry_backoff *= 2
+                continue
+
+        yield response
+        break
 
 
 def _is_transient_error(exc: BaseException) -> bool:

--- a/academy/exchange/cloud/globus.py
+++ b/academy/exchange/cloud/globus.py
@@ -44,11 +44,11 @@ from academy.exception import BadEntityIdError
 from academy.exception import MailboxTerminatedError
 from academy.exception import UnauthorizedError
 from academy.exchange.client_config import ExchangeClientConfig
-from academy.exchange.cloud.app import StatusCode
 from academy.exchange.cloud.client import DEFAULT_EXCHANGE_URL
 from academy.exchange.cloud.login import get_globus_app
 from academy.exchange.cloud.scopes import AcademyExchangeScopes
 from academy.exchange.cloud.scopes import get_academy_exchange_scope_id
+from academy.exchange.cloud.status import StatusCode
 from academy.exchange.factory import ExchangeFactory
 from academy.exchange.transport import ExchangeTransportMixin
 from academy.identifier import AgentId

--- a/academy/exchange/cloud/status.py
+++ b/academy/exchange/cloud/status.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import enum
+
+
+class StatusCode(enum.Enum):
+    """Http status codes."""
+
+    OKAY = 200
+    BAD_REQUEST = 400
+    UNAUTHORIZED = 401
+    FORBIDDEN = 403
+    NOT_FOUND = 404
+    TIMEOUT = 408
+    TOO_LARGE = 413
+    TERMINATED = 419
+    NO_RESPONSE = 444

--- a/tests/unit/exchange/cloud/app_test.py
+++ b/tests/unit/exchange/cloud/app_test.py
@@ -20,10 +20,10 @@ from academy.exchange import HttpExchangeFactory
 from academy.exchange.cloud.app import _main
 from academy.exchange.cloud.app import _run
 from academy.exchange.cloud.app import create_app
-from academy.exchange.cloud.app import StatusCode
 from academy.exchange.cloud.client_info import ClientInfo
 from academy.exchange.cloud.config import ExchangeAuthConfig
 from academy.exchange.cloud.config import ExchangeServingConfig
+from academy.exchange.cloud.status import StatusCode
 from academy.identifier import AgentId
 from academy.identifier import UserId
 from academy.message import Message

--- a/tests/unit/exchange/cloud/client_test.py
+++ b/tests/unit/exchange/cloud/client_test.py
@@ -7,7 +7,6 @@ from typing import Any
 from unittest import mock
 
 import aiohttp
-import aiohttp.web
 import pytest
 
 from academy.exception import BadEntityIdError

--- a/tests/unit/exchange/cloud/client_test.py
+++ b/tests/unit/exchange/cloud/client_test.py
@@ -7,6 +7,7 @@ from typing import Any
 from unittest import mock
 
 import aiohttp
+import aiohttp.web
 import pytest
 
 from academy.exception import BadEntityIdError
@@ -15,16 +16,17 @@ from academy.exception import MailboxTerminatedError
 from academy.exception import UnauthorizedError
 from academy.exchange import HttpExchangeFactory
 from academy.exchange import HttpExchangeTransport
-from academy.exchange.cloud.app import StatusCode
 from academy.exchange.cloud.authenticate import NullAuthenticator
 from academy.exchange.cloud.client import _raise_for_status
 from academy.exchange.cloud.client import spawn_http_exchange
 from academy.exchange.cloud.client_info import ClientInfo
+from academy.exchange.cloud.status import StatusCode
 from academy.identifier import AgentId
 from academy.identifier import UserId
 from academy.message import Message
 from academy.message import PingRequest
 from academy.socket import open_port
+from testing.agents import EmptyAgent
 from testing.constant import TEST_CONNECTION_TIMEOUT
 from testing.constant import TEST_SLEEP_INTERVAL
 from testing.constant import TEST_WAIT_TIMEOUT
@@ -409,7 +411,7 @@ async def test_listen_receive_event(
     async with await http_exchange_factory._create_transport() as transport:
         with mock.patch.object(
             transport,
-            '_request_with_refresh',
+            '_request_with_retry',
             new=mock.MagicMock(),
         ) as mock_request:
             mock_request.return_value = ctx_manager
@@ -418,3 +420,143 @@ async def test_listen_receive_event(
             for _ in range(3):
                 received = await anext(listener)
                 assert received == message
+
+
+@pytest.mark.asyncio
+async def test_client_retry_on_client_error(
+    http_exchange_factory: HttpExchangeFactory,
+) -> None:
+    async with await http_exchange_factory._create_transport() as transport:
+        registration = await transport.register_agent(EmptyAgent)
+        message = Message.create(
+            src=transport.mailbox_id,
+            dest=registration.agent_id,
+            body=PingRequest(),
+        )
+
+        with mock.patch.object(
+            transport._session,
+            'request',
+            new=mock.AsyncMock(),
+        ) as request:
+            request.side_effect = [aiohttp.ClientPayloadError(), mock.Mock()]
+            await transport.send(message)
+            assert request.call_count == 2  # noqa: PLR2004
+
+
+@pytest.mark.asyncio
+async def test_client_no_retry_non_transient_error(
+    http_exchange_factory: HttpExchangeFactory,
+) -> None:
+    async with await http_exchange_factory._create_transport() as transport:
+        registration = await transport.register_agent(EmptyAgent)
+        message = Message.create(
+            src=transport.mailbox_id,
+            dest=registration.agent_id,
+            body=PingRequest(),
+        )
+
+        with mock.patch.object(
+            transport._session,
+            'request',
+            new=mock.AsyncMock(),
+        ) as request:
+            request.side_effect = [RuntimeError('Send failed'), mock.Mock()]
+            with pytest.raises(RuntimeError, match='Send failed'):
+                await transport.send(message)
+
+            assert request.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_client_retry_on_bad_status(
+    http_exchange_factory: HttpExchangeFactory,
+) -> None:
+    mock_response = mock.Mock()
+    mock_response.raise_for_status.side_effect = aiohttp.ClientResponseError(
+        mock.Mock(),
+        mock.Mock(),
+        status=429,
+    )
+
+    async with await http_exchange_factory._create_transport() as transport:
+        registration = await transport.register_agent(EmptyAgent)
+        message = Message.create(
+            src=transport.mailbox_id,
+            dest=registration.agent_id,
+            body=PingRequest(),
+        )
+
+        with mock.patch.object(
+            transport._session,
+            'request',
+            new=mock.AsyncMock(),
+        ) as request:
+            request.side_effect = [mock_response, mock.Mock()]
+            await transport.send(message)
+            assert request.call_count == 2  # noqa: PLR2004
+
+
+@pytest.mark.asyncio
+async def test_client_retry_on_non_transient_status(
+    http_exchange_factory: HttpExchangeFactory,
+) -> None:
+    mock_response = mock.Mock()
+    mock_response.raise_for_status.side_effect = aiohttp.ClientResponseError(
+        mock.Mock(),
+        mock.Mock(),
+        status=400,
+    )
+
+    async with await http_exchange_factory._create_transport() as transport:
+        registration = await transport.register_agent(EmptyAgent)
+        message = Message.create(
+            src=transport.mailbox_id,
+            dest=registration.agent_id,
+            body=PingRequest(),
+        )
+
+        with mock.patch.object(
+            transport._session,
+            'request',
+            new=mock.AsyncMock(),
+        ) as request:
+            request.side_effect = [mock_response, mock.Mock()]
+            with pytest.raises(aiohttp.ClientResponseError):
+                await transport.send(message)
+            assert request.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_client_retry_parameter_respected(
+    http_exchange_server: tuple[str, int],
+) -> None:
+    host, port = http_exchange_server
+    url = f'http://{host}:{port}'
+
+    exchange_factory = HttpExchangeFactory(
+        url,
+        retries=2,
+        initial_retry_backoff=TEST_SLEEP_INTERVAL,
+    )
+
+    async with await exchange_factory._create_transport() as transport:
+        registration = await transport.register_agent(EmptyAgent)
+        message = Message.create(
+            src=transport.mailbox_id,
+            dest=registration.agent_id,
+            body=PingRequest(),
+        )
+
+        with mock.patch.object(
+            transport._session,
+            'request',
+            new=mock.AsyncMock(),
+        ) as request:
+            request.side_effect = [
+                aiohttp.ClientPayloadError,
+                aiohttp.ClientPayloadError,
+                mock.Mock(),
+            ]
+            await transport.send(message)
+            assert request.call_count == 3  # noqa: PLR2004

--- a/tests/unit/exchange/cloud/client_test.py
+++ b/tests/unit/exchange/cloud/client_test.py
@@ -405,16 +405,14 @@ async def test_listen_receive_event(
 
     response = mock.MagicMock()
     response.content.__aiter__.return_value = event_stream
-    ctx_manager = mock.MagicMock()
-    ctx_manager.__aenter__.return_value = response
 
     async with await http_exchange_factory._create_transport() as transport:
         with mock.patch.object(
-            transport,
-            '_request_with_retry',
-            new=mock.MagicMock(),
+            transport._session,
+            'request',
+            new=mock.AsyncMock(),
         ) as mock_request:
-            mock_request.return_value = ctx_manager
+            mock_request.return_value = response
 
             listener = transport.listen(timeout=TEST_WAIT_TIMEOUT)
             for _ in range(3):

--- a/tests/unit/exchange/cloud/globus_test.py
+++ b/tests/unit/exchange/cloud/globus_test.py
@@ -13,13 +13,13 @@ import responses
 from globus_sdk.testing import load_response
 
 from academy.exception import BadEntityIdError
-from academy.exchange.cloud.app import StatusCode
 from academy.exchange.cloud.globus import _AcademyConnectionInfo
 from academy.exchange.cloud.globus import _PendingRegistration
 from academy.exchange.cloud.globus import AcademyAPIError
 from academy.exchange.cloud.globus import AcademyGlobusClient
 from academy.exchange.cloud.globus import GlobusAgentRegistration
 from academy.exchange.cloud.globus import GlobusExchangeTransport
+from academy.exchange.cloud.status import StatusCode
 from academy.identifier import AgentId
 from academy.identifier import UserId
 from academy.message import Message


### PR DESCRIPTION
## Summary
<!--- Provide a summary of the changes --->
Transient errors can affect the connection from the HttpExchangeTransport to the exchange server, we need to deal with these errors gracefully. In the worst case, these transient errors kill some critical task within Academy (i.e. the listening loop) causing an agent to break. I implement a configurable retry loop so that transient errors get retried.


## Related Issues
<!--- List any issue numbers above that this PR addresses --->

- Closes #421 

## Changes
<!--- Check which of the following changes were made --->

- [ ] Breaking (backwards incompatible changes to public interfaces)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change or feature addition)
- [ ] Refactor (internal code or design clean up)
- [ ] Documentation (no changes to the code)
- [ ] Test (changes or additions to testing)
- [ ] Build (change to CI workflows or build processes)
- [ ] Package (changes to package metadata or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

N/A

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added based on the types of changes.
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
