### PR TITLE
Shutdown on Listen Exception

### DIFF
--- a/academy/runtime.py
+++ b/academy/runtime.py
@@ -582,6 +582,7 @@ class Runtime(Generic[AgentT], NoPickleMixin):
             self._exchange_client._listen_for_messages(),
             name=f'exchange-listener-{self.agent_id}',
         )
+        self._exchange_listener_task.add_done_callback(self._listen_monitor)
 
         for name, method in self._loops.items():
             # This guard handles errors in the `_execute_loop` function
@@ -606,6 +607,11 @@ class Runtime(Generic[AgentT], NoPickleMixin):
                 'academy.agent': self.agent,
             },
         )
+
+    def _listen_monitor(self, task: asyncio.Task[None]) -> None:
+        """Callback to shutdown agent if listen loop terminates."""
+        if not task.cancelled() and task.exception() is not None:
+            self.signal_shutdown(expected=False)
 
     def _should_terminate_mailbox(self) -> bool:
         # Inspects the shutdown options and the run config to determine

--- a/tests/unit/runtime_test.py
+++ b/tests/unit/runtime_test.py
@@ -330,6 +330,28 @@ async def test_runtime_cancel_loop(
 
 
 @pytest.mark.asyncio
+async def test_runtime_shutsdown_on_listen_error(
+    exchange_client: UserExchangeClient[LocalExchangeTransport],
+) -> None:
+    registration = await exchange_client.register_agent(EmptyAgent)
+
+    with mock.patch.object(
+        ExchangeClient,
+        '_listen_for_messages',
+        new_callable=mock.AsyncMock,
+    ) as listener:
+        listener.side_effect = Exception('Listen Exception')
+
+        with pytest.raises(Exception, match='Listen Exception'):
+            async with Runtime(  # pragma: no branch
+                EmptyAgent(),
+                exchange_factory=exchange_client.factory(),
+                registration=registration,
+            ) as runtime:
+                await runtime.wait_shutdown(timeout=TEST_WAIT_TIMEOUT)
+
+
+@pytest.mark.asyncio
 async def test_runtime_ping_message(
     exchange_client: UserExchangeClient[LocalExchangeTransport],
 ) -> None:


### PR DESCRIPTION
## Summary
<!--- Provide a summary of the changes --->
Currently when the listening loop of an agent experiences an error, the agent can silently fail. It's unable to receive requests or responses, but may not raise an exception to its manager, and may still send heartbeats back to the exchange. This is a catastrophic error, and when we call `set_academy_debug` this triggers an error to shutdown the agent. I think this is still appropriate, especially for something like the Manager's listening loop where there is no clear action to take to notify the user that something has gone wrong, but for an agent, I think an appropriate action is to shutdown the agent.


## Related Issues
<!--- List any issue numbers above that this PR addresses --->

- Related to #443 

## Changes
<!--- Check which of the following changes were made --->

- [ ] Breaking (backwards incompatible changes to public interfaces)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change or feature addition)
- [ ] Refactor (internal code or design clean up)
- [ ] Documentation (no changes to the code)
- [ ] Test (changes or additions to testing)
- [ ] Build (change to CI workflows or build processes)
- [ ] Package (changes to package metadata or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

N/A

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added based on the types of changes.
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [ ] Docs have been updated and reviewed if relevant.
