### PR TITLE
Fixing bugs in backend message size

### DIFF
--- a/academy/exchange/cloud/backend.py
+++ b/academy/exchange/cloud/backend.py
@@ -583,7 +583,7 @@ class PythonBackend:
 
         if len(message.model_serialize()) > self.message_size_limit:
             raise MessageTooLargeError(
-                sys.getsizeof(message.body),
+                len(message.model_serialize()),
                 self.message_size_limit,
             )
 

--- a/academy/exchange/cloud/backend.py
+++ b/academy/exchange/cloud/backend.py
@@ -581,7 +581,7 @@ class PythonBackend:
                 'Client does not have correct permissions.',
             )
 
-        if sys.getsizeof(message.body) > self.message_size_limit:
+        if len(message.model_serialize()) > self.message_size_limit:
             raise MessageTooLargeError(
                 sys.getsizeof(message.body),
                 self.message_size_limit,

--- a/academy/exchange/cloud/config.py
+++ b/academy/exchange/cloud/config.py
@@ -141,16 +141,24 @@ class BackendConfig(Protocol):
 
 
 class PythonBackendConfig(BaseModel):
-    """Config for using PythonBackend."""
+    """Config for using PythonBackend.
+
+    Attributes:
+        message_size_limit_kb: Maximum message size that can be sent.
+            Bound by the SSE limit imposed by aiohttp.
+
+    """
 
     model_config = ConfigDict(extra='forbid')
 
-    message_size_limit_kb: int = 1024
+    message_size_limit_kb: int = Field(default=512, gt=0, le=512)
     kind: Literal['python'] = Field(default='python', repr=False)
 
     def get_backend(self) -> MailboxBackend:
         """Construct an instance of the backend from the config."""
-        return PythonBackend()
+        return PythonBackend(
+            message_size_limit_kb=self.message_size_limit_kb,
+        )
 
 
 class RedisBackendConfig(BaseModel):
@@ -159,6 +167,11 @@ class RedisBackendConfig(BaseModel):
     Attributes:
         hostname: Redis host
         port: Redis port
+        message_size_limit_kb: Maximum message size that can be sent.
+            Bound by the SSE limit imposed by aiohttp.
+        mailbox_expiration_d: Time till messages expire from mailbox.
+        gravestone_expiration_d: Time till mailbox status is removed.
+            After this, a mailbox may be recreated with the same id.
         kwargs: Any additional args to Redis
     """
 
@@ -166,7 +179,7 @@ class RedisBackendConfig(BaseModel):
 
     hostname: str = 'localhost'
     port: int = 6379
-    message_size_limit_kb: int = Field(default=1024, gt=0, le=1024 * 512)
+    message_size_limit_kb: int = Field(default=512, gt=0, le=512)
     mailbox_expiration_d: float = Field(default=7, gt=0)
     gravestone_expiration_d: float = Field(default=365, gt=0)
     kwargs: dict[str, Any] = Field(default_factory=dict, repr=False)

--- a/tests/unit/exchange/cloud/app_test.py
+++ b/tests/unit/exchange/cloud/app_test.py
@@ -292,11 +292,10 @@ async def test_send_mailbox_message_too_large(cli) -> None:
     aid: AgentId[Any] = AgentId.new()
     cid = UserId.new()
     body = ActionResponse(
-        result=[1] * 513 * 1024,
+        result=[1] * int((512 * 1024) / 3),
         serialization=SerializationStrategy.JSON,
     )
     message = Message.create(src=cid, dest=aid, body=body)
-
     response = await cli.post(
         '/mailbox',
         json={'mailbox': aid.model_dump_json(), 'agent': 'foo'},

--- a/tests/unit/exchange/cloud/app_test.py
+++ b/tests/unit/exchange/cloud/app_test.py
@@ -26,8 +26,10 @@ from academy.exchange.cloud.config import ExchangeServingConfig
 from academy.exchange.cloud.status import StatusCode
 from academy.identifier import AgentId
 from academy.identifier import UserId
+from academy.message import ActionResponse
 from academy.message import Message
 from academy.message import PingRequest
+from academy.serialize import SerializationStrategy
 from academy.socket import open_port
 from academy.socket import wait_connection
 from testing.constant import TEST_CONNECTION_TIMEOUT
@@ -289,32 +291,34 @@ async def test_recv_timeout_error(cli) -> None:
 async def test_send_mailbox_message_too_large(cli) -> None:
     aid: AgentId[Any] = AgentId.new()
     cid = UserId.new()
-    message = Message.create(src=cid, dest=aid, body=PingRequest())
+    body = ActionResponse(
+        result=[1] * 513 * 1024,
+        serialization=SerializationStrategy.JSON,
+    )
+    message = Message.create(src=cid, dest=aid, body=body)
 
-    with mock.patch('sys.getsizeof', return_value=5 * 1024 * 1024):
-        # Create agent
-        response = await cli.post(
-            '/mailbox',
-            json={'mailbox': aid.model_dump_json(), 'agent': 'foo'},
-            headers={'Authorization': 'Bearer user_1'},
-        )
-        assert response.status == StatusCode.OKAY.value
+    response = await cli.post(
+        '/mailbox',
+        json={'mailbox': aid.model_dump_json(), 'agent': 'foo'},
+        headers={'Authorization': 'Bearer user_1'},
+    )
+    assert response.status == StatusCode.OKAY.value
 
-        # Create client
-        response = await cli.post(
-            '/mailbox',
-            json={'mailbox': cid.model_dump_json()},
-            headers={'Authorization': 'Bearer user_1'},
-        )
-        assert response.status == StatusCode.OKAY.value
+    # Create client
+    response = await cli.post(
+        '/mailbox',
+        json={'mailbox': cid.model_dump_json()},
+        headers={'Authorization': 'Bearer user_1'},
+    )
+    assert response.status == StatusCode.OKAY.value
 
-        # Send valid message
-        response = await cli.put(
-            '/message',
-            json={'message': message.model_dump_json()},
-            headers={'Authorization': 'Bearer user_1'},
-        )
-        assert response.status == StatusCode.TOO_LARGE.value
+    # Send valid message
+    response = await cli.put(
+        '/message',
+        json={'message': message.model_dump_json()},
+        headers={'Authorization': 'Bearer user_1'},
+    )
+    assert response.status == StatusCode.TOO_LARGE.value
 
 
 @pytest.mark.asyncio

--- a/tests/unit/exchange/cloud/backend_test.py
+++ b/tests/unit/exchange/cloud/backend_test.py
@@ -20,10 +20,12 @@ from academy.exchange.cloud.client_info import ClientInfo
 from academy.exchange.mailbox_status import MailboxStatus
 from academy.identifier import AgentId
 from academy.identifier import UserId
+from academy.message import ActionResponse
 from academy.message import ErrorResponse
 from academy.message import Message
 from academy.message import PingRequest
 from academy.message import SuccessResponse
+from academy.serialize import SerializationStrategy
 
 BACKEND_TYPES = (PythonBackend, RedisBackend)
 
@@ -401,22 +403,30 @@ async def test_mailbox_backend_remove_mailbox_shares_requires_ownership(
 
 @pytest.mark.asyncio
 async def test_python_backend_message_size() -> None:
-    backend = PythonBackend(message_size_limit_kb=0)
+    backend = PythonBackend(message_size_limit_kb=1)
     uid = UserId.new()
     client = ClientInfo(str(uid), set())
     await backend.create_mailbox(client, uid)
-    message = Message.create(src=uid, dest=uid, body=PingRequest())
+    body = ActionResponse(
+        result=[1] * 1024,
+        serialization=SerializationStrategy.JSON,
+    )
+    message = Message.create(src=uid, dest=uid, body=body)
     with pytest.raises(MessageTooLargeError):
         await backend.put(client, message)
 
 
 @pytest.mark.asyncio
 async def test_redis_backend_message_size(mock_redis) -> None:
-    backend = RedisBackend(message_size_limit_kb=0)
+    backend = RedisBackend(message_size_limit_kb=1)
     uid = UserId.new()
     client = ClientInfo(str(uid), set())
     await backend.create_mailbox(client, uid)
-    message = Message.create(src=uid, dest=uid, body=PingRequest())
+    body = ActionResponse(
+        result=[1] * 1024,
+        serialization=SerializationStrategy.JSON,
+    )
+    message = Message.create(src=uid, dest=uid, body=body)
     with pytest.raises(MessageTooLargeError):
         await backend.put(client, message)
 

--- a/tests/unit/exchange/cloud/config_test.py
+++ b/tests/unit/exchange/cloud/config_test.py
@@ -56,6 +56,20 @@ def test_python_backend_config() -> None:
     assert isinstance(config.get_backend(), PythonBackend)
 
 
+def test_python_backend_config_message_size() -> None:
+    with pytest.raises(ValidationError):
+        PythonBackendConfig(
+            message_size_limit_kb=513,
+        )
+
+
+def test_python_backend_enforces_params() -> None:
+    config = PythonBackendConfig(message_size_limit_kb=256)
+    backend = config.get_backend()
+    assert isinstance(backend, PythonBackend)
+    assert backend.message_size_limit == 256 * 1024
+
+
 def test_redis_backend_config_default() -> None:
     config = RedisBackendConfig()
     assert isinstance(config.get_backend(), RedisBackend)
@@ -64,8 +78,15 @@ def test_redis_backend_config_default() -> None:
 def test_redis_backend_config_message_size() -> None:
     with pytest.raises(ValidationError):
         RedisBackendConfig(
-            message_size_limit_kb=513 * 1024,
+            message_size_limit_kb=513,
         )
+
+
+def test_redis_backend_enforces_params() -> None:
+    config = RedisBackendConfig(message_size_limit_kb=256)
+    backend = config.get_backend()
+    assert isinstance(backend, RedisBackend)
+    assert backend.message_size_limit == 256 * 1024
 
 
 def test_read_from_config_file_empty(tmp_path: pathlib.Path) -> None:


### PR DESCRIPTION
## Summary
<!--- Provide a summary of the changes --->
During his summer project, Alex used the PythonBackend quite a bit for testing and found some issues. These fixes address those issues. One of the was the backend config did not actually pass a parameter into the created object, another one was that SSE has a line length limit.


## Related Issues
<!--- List any issue numbers above that this PR addresses --->
- Close #443 
- Closes #444

## Changes
<!--- Check which of the following changes were made --->

- [ ] Breaking (backwards incompatible changes to public interfaces)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change or feature addition)
- [ ] Refactor (internal code or design clean up)
- [ ] Documentation (no changes to the code)
- [ ] Test (changes or additions to testing)
- [ ] Build (change to CI workflows or build processes)
- [ ] Package (changes to package metadata or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

N/A

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added based on the types of changes.
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [ ] New and existing unit tests pass locally with the changes.
- [ ] Docs have been updated and reviewed if relevant.
