### PR TITLE
Adding academy version to message and http headers

### DIFF
--- a/academy/exchange/cloud/client.py
+++ b/academy/exchange/cloud/client.py
@@ -28,6 +28,7 @@ from aiohttp import hdrs
 from pydantic import BaseModel
 from pydantic import Field
 
+from academy import __version__
 from academy.exception import BadEntityIdError
 from academy.exception import ForbiddenError
 from academy.exception import MailboxTerminatedError
@@ -124,9 +125,12 @@ class HttpExchangeTransport(ExchangeTransportMixin, NoPickleMixin):
         if connection_info.client_timeout is not None:  # pragma: no branch
             session_kwargs['timeout'] = connection_info.client_timeout
 
+        additional_headers = {
+            'academy_version': __version__,
+        } | connection_info.additional_headers
         session = aiohttp.ClientSession(
             connector=aiohttp.TCPConnector(ssl=ssl_verify),
-            headers=connection_info.additional_headers,
+            headers=additional_headers,
             trust_env=True,
             **session_kwargs,
         )
@@ -454,9 +458,12 @@ class HttpExchangeConsole:
         if connection_info.client_timeout is not None:  # pragma: no branch
             session_kwargs['timeout'] = connection_info.client_timeout
 
+        additional_headers = {
+            'academy_version': __version__,
+        } | connection_info.additional_headers
         session = aiohttp.ClientSession(
             connector=aiohttp.TCPConnector(ssl=ssl_verify),
-            headers=connection_info.additional_headers,
+            headers=additional_headers,
             trust_env=True,
             **session_kwargs,
         )

--- a/academy/exchange/cloud/globus.py
+++ b/academy/exchange/cloud/globus.py
@@ -40,6 +40,7 @@ from globus_sdk.transport.requests import RequestsTransport
 from pydantic import BaseModel
 from pydantic import Field
 
+from academy import __version__
 from academy.exception import BadEntityIdError
 from academy.exception import MailboxTerminatedError
 from academy.exception import UnauthorizedError
@@ -118,6 +119,7 @@ class AcademyGlobusClient(globus_sdk.BaseClient):
                 'agent': agent_str,
                 'allow_subclasses': allow_subclasses,
             },
+            headers={'academy_version': __version__},
         )
 
     def recv(
@@ -132,6 +134,7 @@ class AcademyGlobusClient(globus_sdk.BaseClient):
                 'mailbox': mailbox_id.model_dump_json(),
                 'timeout': timeout,
             },
+            headers={'academy_version': __version__},
         )
 
     def register_agent(
@@ -145,6 +148,7 @@ class AcademyGlobusClient(globus_sdk.BaseClient):
                 'mailbox': agent_id.model_dump_json(),
                 'agent': ','.join(agent._agent_mro()),
             },
+            headers={'academy_version': __version__},
         )
 
     def register_client(
@@ -156,12 +160,14 @@ class AcademyGlobusClient(globus_sdk.BaseClient):
             data={
                 'mailbox': mailbox_id.model_dump_json(),
             },
+            headers={'academy_version': __version__},
         )
 
     def send(self, message: Message[Any]) -> GlobusHTTPResponse:
         return self.put(
             self._message_url,
             data={'message': message.model_dump_json()},
+            headers={'academy_version': __version__},
         )
 
     def terminate(self, uid: EntityId) -> GlobusHTTPResponse:
@@ -169,6 +175,7 @@ class AcademyGlobusClient(globus_sdk.BaseClient):
             'DELETE',
             self._mailbox_url,
             data={'mailbox': uid.model_dump_json()},
+            headers={'academy_version': __version__},
         )
 
     def get_heartbeat(self, uid: EntityId) -> GlobusHTTPResponse:
@@ -176,6 +183,7 @@ class AcademyGlobusClient(globus_sdk.BaseClient):
             'GET',
             self._heartbeat_url,
             data={'mailbox': uid.model_dump_json()},
+            headers={'academy_version': __version__},
         )
 
     def update_heartbeat(self, uid: EntityId) -> GlobusHTTPResponse:
@@ -183,6 +191,7 @@ class AcademyGlobusClient(globus_sdk.BaseClient):
             'POST',
             self._heartbeat_url,
             data={'mailbox': uid.model_dump_json()},
+            headers={'academy_version': __version__},
         )
 
     def get_agent_stats(self, uid: EntityId) -> GlobusHTTPResponse:
@@ -190,6 +199,7 @@ class AcademyGlobusClient(globus_sdk.BaseClient):
             'GET',
             self._agent_stats_url,
             data={'mailbox': uid.model_dump_json()},
+            headers={'academy_version': __version__},
         )
 
 

--- a/academy/message.py
+++ b/academy/message.py
@@ -26,6 +26,7 @@ from pydantic import field_serializer
 from pydantic import SkipValidation
 from pydantic import TypeAdapter
 
+from academy import __version__
 from academy.exception import ActionCancelledError
 from academy.exception import ActionInvalidStateError
 from academy.exception import ExceptionSerializationError
@@ -52,7 +53,7 @@ DEFAULT_MUTABLE_CONFIG = ConfigDict(
     validate_default=True,
 )
 
-PROTOCOL_VERSION: Version = Version('1')
+PROTOCOL_VERSION: Version = Version('1.1')
 
 
 def check_version(version: str | None) -> bool:
@@ -401,6 +402,16 @@ class Header(BaseModel):
             'existing fields without prohibiting their existence.'
         ),
     )
+    academy_version: str = Field(
+        '0.5.0',
+        description=(
+            'Communicate the academy version so decisions can be made '
+            'based off the version number (for instance if a feature '
+            'later implemented can be invoked). Messages without a '
+            'version are assumed to be v0.5.0 (the only version using '
+            'this protocol version without the academy_version field).'
+        ),
+    )
 
     model_config = DEFAULT_FROZEN_CONFIG
 
@@ -426,6 +437,7 @@ class Header(BaseModel):
             dest=self.src,
             label=self.label,
             kind='response',
+            academy_version=__version__,
         )
 
 
@@ -483,6 +495,11 @@ class Message(BaseModel, Generic[BodyT]):
         """Message protocol version."""
         return self.header.protocol_version
 
+    @property
+    def academy_version(self) -> str:
+        """Message protocol version."""
+        return self.header.academy_version
+
     @classmethod
     def create(
         cls,
@@ -515,7 +532,14 @@ class Message(BaseModel, Generic[BodyT]):
         if tag is None:
             tag = uuid.uuid4()
 
-        header = Header(src=src, dest=dest, label=label, kind=kind, tag=tag)
+        header = Header(
+            src=src,
+            dest=dest,
+            label=label,
+            kind=kind,
+            tag=tag,
+            academy_version=__version__,
+        )
         request: Message[BodyT] = Message(header=header, body=body)
         return request
 

--- a/tests/unit/message_test.py
+++ b/tests/unit/message_test.py
@@ -9,6 +9,7 @@ import pydantic
 import pytest
 from pydantic import Field
 
+from academy import __version__
 from academy.exception import ActionCancelledError
 from academy.exception import ActionInvalidStateError
 from academy.exception import ExceptionSerializationError
@@ -290,7 +291,7 @@ def test_compatible_major_version() -> None:
                 'src': AgentId.new(),
                 'dest': AgentId.new(),
                 'tag': uuid.uuid4(),
-                'protocol_version': '1.1',
+                'protocol_version': '1.100',
                 'kind': 'request',
             },
             'body': NewActionRequest(
@@ -305,3 +306,28 @@ def test_compatible_major_version() -> None:
     body = message.get_body()
     assert isinstance(body, ActionRequest)
     assert not isinstance(body, NewActionRequest)
+
+
+def test_header_academy_version_default() -> None:
+    message = Message.create(
+        src=AgentId.new(),
+        dest=AgentId.new(),
+        body=SuccessResponse(),
+    )
+    assert message.academy_version == __version__
+
+
+def test_header_academy_version_missing() -> None:
+    message: Message[SuccessResponse] = Message.model_validate(
+        {
+            'header': {
+                'src': AgentId.new(),
+                'dest': AgentId.new(),
+                'tag': uuid.uuid4(),
+                'protocol_version': '1.0',
+                'kind': 'response',
+            },
+            'body': SuccessResponse().model_dump(),
+        },
+    )
+    assert message.academy_version == '0.5.0'


### PR DESCRIPTION
## Summary
<!--- Provide a summary of the changes --->
As we move to version 1.0, some new features might need the academy version to make decisions. The most recent example of this was adding heartbeats. If we knew the academy version of agents, we could conclude whether missing heartbeats meant the agent was inactive, or if the agent was using a version of Academy without heartbeats. 

I added the version to two places. One is the `Header` of the message --- this will be passed to client agents, so they can make determinations of which agents they are communicating with. One is the http header communicated to the exchange, so it can be used on the exchange side even for requests that are not using the Academy `Message` data structure.
Default values are intentionally implemented to avoid breaking with existing versions of Academy so we do not need a major protocol version upgrade.

## Related Issues
<!--- List any issue numbers above that this PR addresses --->

- Closes #453 

## Changes
<!--- Check which of the following changes were made --->

- [ ] Breaking (backwards incompatible changes to public interfaces)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change or feature addition)
- [ ] Refactor (internal code or design clean up)
- [ ] Documentation (no changes to the code)
- [ ] Test (changes or additions to testing)
- [ ] Build (change to CI workflows or build processes)
- [ ] Package (changes to package metadata or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

N/A

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added based on the types of changes.
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
